### PR TITLE
Integrate gutenberg-mobile release 99.99.99

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     ext.kotlin_ktx_version = '1.2.0'
     ext.wordPressUtilsVersion = '1.30.3-beta.3'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = 'develop-8efdc5bc5715f352cde72741b01b503399bf42c7'
+    ext.gutenbergMobileVersion = '125-0abd817ec9f51699ff170a0f6aa8d832d2fe6712'
 
     repositories {
         google()


### PR DESCRIPTION
## Description
This PR incorporates the 99.99.99 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/cameronvoell/gutenberg-mobile/pull/125

Release Submission Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.